### PR TITLE
Change ::shadow to .editor per deprecation warning

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -2,7 +2,7 @@
 @import "icon-variables";
 @import "ui-mixins";
 
-atom-text-editor[mini], atom-text-editor[mini]::shadow {
+atom-text-editor[mini], atom-text-editor[mini].editor {
   color: @input-text-color;
   background-color: @input-background-color-selected;
   border: 1px solid @input-border-color;
@@ -14,13 +14,13 @@ atom-text-editor[mini], atom-text-editor[mini]::shadow {
   .selection .region { background-color: darken(@input-background-color, 10%); }
 }
 
-atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused::shadow {
+atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused.editor {
   color: @input-text-color-selected;
   background-color: @input-background-color;
   .selection .region { background-color: desaturate(@background-color-info, 50%); }
 }
 
-atom-text-editor, atom-text-editor::shadow {
+atom-text-editor, atom-text-editor.editor {
   .gutter .line-number {
     padding-left: 10px;
   }
@@ -72,7 +72,7 @@ atom-text-editor, atom-text-editor::shadow {
     padding: 3px 0px 0px 6px;
   }
 
-  atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused::shadow {
+  atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused.editor {
     padding: 1px;
   }
 }

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -114,7 +114,7 @@ atom-pane-container atom-pane .item-views .pane-item {
   }
 
   atom-text-editor .placeholder-text, // <-- deprecated
-  atom-text-editor::shadow .placeholder-text {
+  atom-text-editor.editor .placeholder-text {
     color: lighten(@text-color-subtle, 15%);
   }
 


### PR DESCRIPTION
I've been using (and loving) this theme, but lately the deprecation cop has not been as happy ;) `::shadow` is going away, and the auto-fix will be removed at some point, so this addresses the requested changes.